### PR TITLE
Clarify that a Qualifying Audit is needed.

### DIFF
--- a/trusted-root-docs/Program-Requirements.md
+++ b/trusted-root-docs/Program-Requirements.md
@@ -23,7 +23,7 @@ The Microsoft Root Certificate Program supports the distribution of root certifi
 ## 2. Continuing Program Requirements
 ### Audit Requirements
 
-1.  Program Participants must provide to Microsoft evidence of a Qualified Audit (see <https://aka.ms/auditreqs>) for each root, unconstrained subordinate CA, , and cross-signed certificate, before conducting commercial operations and thereafter on an annual basis.
+1.  Program Participants must provide to Microsoft evidence of a Qualifying Audit (see <https://aka.ms/auditreqs>) for each root, unconstrained subordinate CA, , and cross-signed certificate, before conducting commercial operations and thereafter on an annual basis.
 2.  Program Participants must assume responsibility to ensure that all unconstrained subordinate CAs and cross-signed certificates meet the Program Audit Requirements.
 3. CAs must publicly disclose all audit reports for unconstrained subordinate CAs.
 


### PR DESCRIPTION
The current language suggests that a Qualified Audit is needed. According to
ISAE 3000 and the WebTrust International Reporting under ISAE3000, the term
Qualified has a different meaning within the context of Audits. This commit
clarifies that a Qualifying Audit is needed, according to the requirements
stated in https://aka.ms/auditreqs.