### PR TITLE
GA rename: Threat Hunting Assistant

### DIFF
--- a/security-docs/zero-trust/prioritizing-defense/scan-secure-source-code.md
+++ b/security-docs/zero-trust/prioritizing-defense/scan-secure-source-code.md
@@ -55,7 +55,7 @@ Secure your development lifecycle from code to cloud by connecting your source c
 
 ## Accelerate with AI-powered agents
 
-- The **Threat Hunting Agent** in Microsoft Defender enables analysts to investigate suspicious activity across code, pipelines, and runtime workloads using natural language queries, translating them into Kusto Query Language (KQL) and surfacing contextual insights without requiring manual query composition. For more information, see [Microsoft Security Copilot Threat Hunting Agent in advanced hunting](/defender-xdr/advanced-hunting-security-copilot-threat-hunting-agent).
+- The **Threat Hunting Assistant** in Microsoft Defender enables analysts to investigate suspicious activity across code, pipelines, and runtime workloads using natural language queries, translating them into Kusto Query Language (KQL) and surfacing contextual insights without requiring manual query composition. For more information, see [Microsoft Security Copilot Threat Hunting Assistant in advanced hunting](/defender-xdr/advanced-hunting-security-copilot-threat-hunting-assistant).
 
 ## Related content
 


### PR DESCRIPTION
## Summary
- Rename Threat Hunting Agent to Threat Hunting Assistant for GA
- Update related links/slug references
- Remove preview labeling for this feature where present

## GA coordination
Draft PR for review only. Do not merge or publish before Aug 5 GA approval.

## Validation
- Text-only documentation updates