### PR TITLE
GA rename: Threat Hunting Assistant

### DIFF
--- a/security-docs/zero-trust/prioritizing-defense/scan-secure-source-code.md
+++ b/security-docs/zero-trust/prioritizing-defense/scan-secure-source-code.md
@@ -55,7 +55,7 @@ Secure your development lifecycle from code to cloud by connecting your source c
 
 ## Accelerate with AI-powered agents
 
-- The **Threat Hunting Agent** in Microsoft Defender enables analysts to investigate suspicious activity across code, pipelines, and runtime workloads using natural language queries, translating them into Kusto Query Language (KQL) and surfacing contextual insights without requiring manual query composition. For more information, see [Microsoft Security Copilot Threat Hunting Agent in advanced hunting](/defender-xdr/advanced-hunting-security-copilot-threat-hunting-agent).
+- The **Threat Hunting Assistant** in Microsoft Defender enables analysts to investigate suspicious activity across code, pipelines, and runtime workloads using natural language queries, translating them into Kusto Query Language (KQL) and surfacing contextual insights without requiring manual query composition. For more information, see [Microsoft Security Copilot Threat Hunting Assistant in advanced hunting](/defender-xdr/advanced-hunting-security-copilot-threat-hunting-assistant).
 
 ## Related content
 


### PR DESCRIPTION
## Summary

Renames **Threat Hunting Agent** to **Threat Hunting Assistant** for GA in the Zero Trust guidance, and updates the link to the renamed article.

Text-only. No screenshots in this article.

Naming note: **Security Analyst Agent keeps "Agent"**. Only the Threat Hunting one becomes Assistant.

## GA coordination

Draft PR for review only. **Do not merge or publish before Aug 5 GA approval.**

Related PRs:
- MicrosoftDocs/defender-docs#561
- MicrosoftDocs/learn#58
- MicrosoftDocs/security-copilot-pr#1088
